### PR TITLE
Depend on puppetlabs/stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,10 @@
   "project_page": "https://github.com/voxpupuli/puppet-sssd",
   "issues_url": "https://github.com/voxpupuli/puppet-sssd/issues",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">=4.13.0"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Otherwise ModuleLoader hides it and I get
> Resource type not found: Stdlib::Absolutepath

I chose 4.13.0 because it included Stdlib::Absolutepath.

#### This Pull Request (PR) fixes the following issues
n/a