### PR TITLE
Ignore files permissions on distros having sssd >= 2.10 (Closes #24)

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,12 +10,6 @@ sssd::main_pki_dir: /etc/sssd/pki
 sssd::main_config_file: /etc/sssd/sssd.conf
 sssd::config_d_location: /etc/sssd/conf.d
 sssd::purge_unmanaged_conf_d: true
-sssd::pki_owner: root
-sssd::pki_group: root
-sssd::pki_mode: '0711'
-sssd::config_owner: root
-sssd::config_group: root
-sssd::config_mode: '0600'
 sssd::main_config:
   sssd: {}
 sssd::configs: {}

--- a/manifests/base_config.pp
+++ b/manifests/base_config.pp
@@ -18,6 +18,10 @@
 #   Group for the config files - should be 'root'
 # @param config_mode
 #   chmod for the config files - should be '0600'
+# @param config_dir_mode
+#   chmod for main config directory - should probably be '0750' or '0700'
+# @param config_d_mode
+#   chmod for conf.d sub-directory - should probably be '0750', '0711' or '0700'
 # @param main_config
 #   Hash containing the content of $main_config_file broken out by section
 #   Entries in $config_d_location can replace these elements in a last
@@ -41,6 +45,8 @@ class sssd::base_config (
   $config_owner = $sssd::config_owner,
   $config_group = $sssd::config_group,
   $config_mode = $sssd::config_mode,
+  $config_dir_mode = $sssd::config_dir_mode,
+  $config_d_mode = $sssd::config_d_mode,
   $main_config = $sssd::main_config,
   $configs = $sssd::configs,
   # lint:endignore
@@ -48,39 +54,53 @@ class sssd::base_config (
   assert_private()
 
   if $config_manage {
+
+    # Use computed default values for file permissions depending on running OS
+    include sssd::os_defaults
+    $permission_defaults = $sssd::os_defaults::permission_defaults
+    $eff_pki_owner       = $pki_owner       ? { undef => $permission_defaults['pki_owner'],       default => $pki_owner }
+    $eff_pki_group       = $pki_group       ? { undef => $permission_defaults['pki_group'],       default => $pki_group }
+    $eff_pki_mode        = $pki_mode        ? { undef => $permission_defaults['pki_mode'],        default => $pki_mode }
+    $eff_config_owner    = $config_owner    ? { undef => $permission_defaults['config_owner'],    default => $config_owner }
+    $eff_config_group    = $config_group    ? { undef => $permission_defaults['config_group'],    default => $config_group }
+    $eff_config_mode     = $config_mode     ? { undef => $permission_defaults['config_mode'],     default => $config_mode }
+    $eff_config_dir_mode = $config_dir_mode ? { undef => $permission_defaults['config_dir_mode'], default => $config_dir_mode }
+    $eff_config_d_mode   = $config_d_mode   ? { undef => $permission_defaults['config_d_mode'],   default => $config_d_mode }
+    #fail("eff_pki_group=${eff_pki_group} permission_defaults_pki_group=${permission_defaults['pki_group']} pki_group=${pki_group}")
+
     file { $main_config_dir:
       ensure => 'directory',
-      owner  => $config_owner,
-      group  => $config_group,
-      mode   => $config_mode,
+      owner  => $eff_config_owner,
+      group  => $eff_config_group,
+      mode   => $eff_config_dir_mode,
     }
 
     file { $main_pki_dir:
       ensure => 'directory',
-      owner  => $pki_owner,
-      group  => $pki_group,
-      mode   => $pki_mode,
+      owner  => $eff_pki_owner,
+      group  => $eff_pki_group,
+      mode   => $eff_pki_mode,
     }
 
     file { $config_d_location:
       ensure  => 'directory',
-      owner   => $config_owner,
-      group   => $config_group,
-      mode    => $config_mode,
+      owner   => $eff_config_owner,
+      group   => $eff_config_group,
+      mode    => $eff_config_d_mode,
       recurse => $purge_unmanaged_conf_d,
       purge   => $purge_unmanaged_conf_d,
     }
 
     sssd::config { $main_config_file:
-      owner               => $config_owner,
-      group               => $config_group,
-      mode                => $config_mode,
+      owner               => $eff_config_owner,
+      group               => $eff_config_group,
+      mode                => $eff_config_mode,
       stanzas             => $main_config,
       force_this_filename => $main_config_file,
     }
 
     # lint:ignore:140chars
-    create_resources(sssd::config, $configs, { 'owner' => $config_owner, 'group' => $config_group, 'mode' => $config_mode })
+    create_resources(sssd::config, $configs, { 'owner' => $eff_config_owner, 'group' => $eff_config_group, 'mode' => $eff_config_mode })
     # lint:endignore
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,16 +22,28 @@
 #   Should we remove any files unknown to puppet in the conf_d location?
 # @param pki_owner
 #   Owner for the pki directory - should probably be 'root' or 'sssd'
+#   Leave undef for auto-detect for running OS
 # @param pki_group
 #   Group for the pki directory - should probably be 'root' or 'sssd'
+#   Leave undef for auto-detect for running OS
 # @param pki_mode
-#   Group for the pki directory - should probably be '0711'
+#   Permissions for the pki directory - should probably be '0711'
+#   Leave undef for auto-detect for running OS
 # @param config_owner
 #   Owner for the config files - should probably be 'root' or 'sssd'
+#   Leave undef for auto-detect for running OS
 # @param config_group
 #   Group for the config files - should probably be 'root' or 'sssd'
+#   Leave undef for auto-detect for running OS
 # @param config_mode
-#   chmod for the config files - should be '0600'
+#   Permissions for the config files - should be '0600'
+#   Leave undef for auto-detect for running OS
+# @param config_dir_mode
+#   Permissions for main config directory - should probably be '0750' or '0700'
+#   Leave undef for auto-detect for running OS
+# @param config_d_mode
+#   Permissions for conf.d sub-directory - should probably be '0750', '0711' or '0700'
+#   Leave undef for auto-detect for running OS
 # @param main_config
 #   Hash containing the content of $main_config_file broken out by section
 #   Entries in $config_d_location can replace these elements in a last
@@ -76,12 +88,14 @@ class sssd (
   Stdlib::Absolutepath $main_config_file,
   Stdlib::Absolutepath $config_d_location,
   Stdlib::Absolutepath $main_pki_dir,
-  String $pki_owner,
-  String $pki_group,
-  String $pki_mode,
-  String $config_owner,
-  String $config_group,
-  String $config_mode,
+  Optional[String] $pki_owner = undef,
+  Optional[String] $pki_group = undef,
+  Optional[String] $pki_mode = undef,
+  Optional[String] $config_owner = undef,
+  Optional[String] $config_group = undef,
+  Optional[String] $config_mode = undef,
+  Optional[String] $config_dir_mode = undef,
+  Optional[String] $config_d_mode = undef,
   Boolean $purge_unmanaged_conf_d,
   Hash $main_config,
   Hash $configs,

--- a/manifests/os_defaults.pp
+++ b/manifests/os_defaults.pp
@@ -1,0 +1,145 @@
+# @summary Computes SSSD files permission depending on target OS
+#
+# Recent distributions ships SSSD package rewriting permission in their systemd service file
+# See: https://github.com/voxpupuli/puppet-sssd/issues/24
+#
+# RedHat-based (new), RHEL >= 10 or Fedora >= 41
+#   /etc/sssd/        => 0750 root:sssd
+#   /etc/sssd/conf.d/ => 0750 root:sssd
+#   /etc/sssd/pki/    => 0750 root:sssd
+#   sssd.conf         => 0640 root:sssd
+#
+# RedHat-based (old), RHEL < 10 or Fedora < 41
+#   /etc/sssd/        => 0700 sssd:sssd
+#   /etc/sssd/conf.d/ => 0711 sssd:sssd
+#   /etc/sssd/pki/    => 0711 root:root
+#   sssd.conf         => 0600 root:root
+#
+# Debian-based (new), Debian >= 13, 
+#   /etc/sssd/        => 0740 root:root
+#   /etc/sssd/conf.d/ => 0740 root:root
+#   /etc/sssd/pki/    => 0751 root:root
+#   sssd.conf         => 0640 root:root
+#
+# Debian-based (old)
+#   /etc/sssd/        => 0700 root:root
+#   /etc/sssd/conf.d/ => 0700 root:root
+#   /etc/sssd/pki/    => 0711 root:root
+#   sssd.conf         => 0600 root:root
+#
+# Other systems gets default root config like Debian-based
+#
+class sssd::os_defaults {
+  assert_private()
+
+  # Extract distribution facts
+  $osfamily = $facts['os']['family']
+  $osname = $facts['os']['name']
+  $osreleasemajor = $facts['os']['release']['major']
+
+  # Check we are on modern RHEL or derivative
+  $rhel_based = [
+    'RedHat',
+    'CentOS',
+    'Rocky',
+    'AlmaLinux',
+    'OracleLinux',
+  ]
+  $is_modern_rhel = $osname in $rhel_based and versioncmp($osreleasemajor, '10') >= 0
+  $is_modern_fedora = $osname == 'Fedora' and versioncmp($osreleasemajor, '41') >= 0
+
+  # Check we are on legacy RHEL or Fedora
+  $is_legacy_rhel = $osname in $rhel_based and versioncmp($osreleasemajor, '10') < 0
+  $is_legacy_fedora = $osname == 'Fedora' and versioncmp($osreleasemajor, '41') < 0
+
+  # Check if we are on modern Debian/Ubuntu (chmod -R g+r in systemd service)
+  $is_modern_debian = $osname == 'Debian' and versioncmp($osreleasemajor, '13') >= 0
+  $is_modern_ubuntu = $osname == 'Ubuntu' and versioncmp($osreleasemajor, '25.04') >= 0
+  
+  # Check if we are on legacy Debian/Ubuntu
+  $is_legacy_debian = $osname == 'Debian' and versioncmp($osreleasemajor, '13') < 0
+  $is_legacy_ubuntu = $osname == 'Ubuntu' and versioncmp($osreleasemajor, '25.04') < 0
+
+  if ($is_modern_rhel or $is_modern_fedora) {
+    # Modern RedHat based
+    $permission_defaults = {
+      'config_dir_owner' => 'root',
+      'config_dir_group' => 'sssd',
+      'config_dir_mode'  => '0750',
+      'pki_owner'        => 'root',
+      'pki_group'        => 'sssd',
+      'pki_mode'         => '0750',
+      'config_d_owner'   => 'root',
+      'config_d_group'   => 'sssd',
+      'config_d_mode'    => '0750',
+      'config_owner'     => 'root',
+      'config_group'     => 'sssd',
+      'config_mode'      => '0640',
+    }
+  } elsif ($is_legacy_rhel or $is_legacy_fedora) {
+    # Legacy RedHat based
+    $permission_defaults = {
+      'config_dir_owner' => 'root',
+      'config_dir_group' => 'root',
+      'config_dir_mode'  => '0700',
+      'pki_owner'        => 'root',
+      'pki_group'        => 'root',
+      'pki_mode'         => '0711',
+      'config_d_owner'   => 'root',
+      'config_d_group'   => 'root',
+      'config_d_mode'    => '0711',
+      'config_owner'     => 'root',
+      'config_group'     => 'root',
+      'config_mode'      => '0600',
+    }
+  } elsif ($is_modern_debian or $is_modern_ubuntu) {
+    # Modern Debian/Ubuntu perform g+r in init script
+    $permission_defaults = {
+      'config_dir_owner' => 'root',
+      'config_dir_group' => 'root',
+      'config_dir_mode'  => '0740',
+      'pki_owner'        => 'root',
+      'pki_group'        => 'root',
+      'pki_mode'         => '0750',
+      'config_d_owner'   => 'root',
+      'config_d_group'   => 'root',
+      'config_d_mode'    => '0750',
+      'config_owner'     => 'root',
+      'config_group'     => 'root',
+      'config_mode'      => '0640',
+    }
+  } elsif ($is_legacy_debian or $is_legacy_ubuntu) {
+    # Legacy Debian/Ubuntu
+    $permission_defaults = {
+      'config_dir_owner' => 'root',
+      'config_dir_group' => 'root',
+      'config_dir_mode'  => '0700',
+      'pki_owner'        => 'root',
+      'pki_group'        => 'root',
+      'pki_mode'         => '0700',
+      'config_d_owner'   => 'root',
+      'config_d_group'   => 'root',
+      'config_d_mode'    => '0700',
+      'config_owner'     => 'root',
+      'config_group'     => 'root',
+      'config_mode'      => '0600',
+    }
+  } else {
+    # Unknown system
+    # Use default root/root permissions like legacy Debian
+    $permission_defaults = {
+      'config_dir_owner' => 'root',
+      'config_dir_group' => 'root',
+      'config_dir_mode'  => '0700',
+      'pki_owner'        => 'root',
+      'pki_group'        => 'root',
+      'pki_mode'         => '0700',
+      'config_d_owner'   => 'root',
+      'config_d_group'   => 'root',
+      'config_d_mode'    => '0700',
+      'config_owner'     => 'root',
+      'config_group'     => 'root',
+      'config_mode'      => '0600',
+    }
+  }
+}


### PR DESCRIPTION
#### Pull Request (PR) description

Disable file permissions enforcement (mode => undef) on the following distributions:
- RedHat/CentOS/Rocky >= 10
- Fedora >= 41
- Debian >= 13
- Ubuntu >= 25.04

This is necessary because these distributions ship SSSD >= 2.10 that also enforce permissions from its systemd service file, so it is getting overwritten as soon as being applied, right after service is notified for restart

#### This Pull Request (PR) fixes the following issues

Fixes #24
