### PR TITLE
Allow more specific file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,26 @@ setting=value, b
 debug=0
 ```
 
+### Version 2.10.0 and newer
+
+Newer versions of sssd runs as user sssd instead of root. The module currently assumes that the service is running as root. The changes below will allow it to run as the sssd user.
+
+```yaml
+sssd::pki_group: sssd
+sssd::pki_mode: '0751'
+sssd::advanced_permissions: true
+```
+
+The following parameters can be used to tweak owner and group ownership and file mode for directories and files:
+```
+sssd::config_dir_owner
+sssd::config_dir_group
+sssd::config_dir_mode
+sssd::main_config_owner
+sssd::main_config_group
+sssd::main_config_mode
+```
+
 ## Limitations
 
 This module specifically does not manipulate files or services

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -73,6 +73,13 @@ The following parameters are available in the `sssd` class:
 * [`services_ensure`](#-sssd--services_ensure)
 * [`services_enable`](#-sssd--services_enable)
 * [`service_names`](#-sssd--service_names)
+* [`advanced_permissions`](#-sssd--advanced_permissions)
+* [`config_dir_owner`](#-sssd--config_dir_owner)
+* [`config_dir_group`](#-sssd--config_dir_group)
+* [`config_dir_mode`](#-sssd--config_dir_mode)
+* [`main_config_owner`](#-sssd--main_config_owner)
+* [`main_config_group`](#-sssd--main_config_group)
+* [`main_config_mode`](#-sssd--main_config_mode)
 
 ##### <a name="-sssd--packages_manage"></a>`packages_manage`
 
@@ -204,6 +211,48 @@ Service enable parameter
 Data type: `Array[String]`
 
 Array of services that are part of sssd
+
+##### <a name="-sssd--advanced_permissions"></a>`advanced_permissions`
+
+Data type: `Boolean`
+
+Enable permission handling for files/directories
+
+##### <a name="-sssd--config_dir_owner"></a>`config_dir_owner`
+
+Data type: `String`
+
+Owner for configuration directories ($main_config_dir and $config_d_location)
+
+##### <a name="-sssd--config_dir_group"></a>`config_dir_group`
+
+Data type: `String`
+
+Group for configuration directories ($main_config_dir and $config_d_location)
+
+##### <a name="-sssd--config_dir_mode"></a>`config_dir_mode`
+
+Data type: `Stdlib::Filemode`
+
+chmod for configuration directories ($main_config_dir and $config_d_location)
+
+##### <a name="-sssd--main_config_owner"></a>`main_config_owner`
+
+Data type: `String`
+
+Owner for configuration files ($main_config_file and resoures created by $configs)
+
+##### <a name="-sssd--main_config_group"></a>`main_config_group`
+
+Data type: `String`
+
+Group for configuration files ($main_config_file and resoures created by $configs)
+
+##### <a name="-sssd--main_config_mode"></a>`main_config_mode`
+
+Data type: `Stdlib::Filemode`
+
+chmod for configuration files ($main_config_file and resoures created by $configs)
 
 ## Defined types
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,6 +19,13 @@ sssd::config_mode: '0600'
 sssd::main_config:
   sssd: {}
 sssd::configs: {}
+sssd::advanced_permissions: false
+sssd::config_dir_owner: root
+sssd::config_dir_group: sssd
+sssd::config_dir_mode: '0750'
+sssd::main_config_owner: root
+sssd::main_config_group: sssd
+sssd::main_config_mode: '0640'
 
 sssd::services_manage: true
 sssd::services_ensure: running

--- a/manifests/base_config.pp
+++ b/manifests/base_config.pp
@@ -27,6 +27,20 @@
 #   'any text you want':
 #     section:
 #       key: value
+# @param advanced_permissions
+#   Enable permission handling for files/directories
+# @param config_dir_owner
+#   Owner for configuration directories ($main_config_dir and $config_d_location)
+# @param config_dir_group
+#   Group for configuration directories ($main_config_dir and $config_d_location)
+# @param config_dir_mode
+#   chmod for configuration directories ($main_config_dir and $config_d_location)
+# @param main_config_owner
+#   Owner for configuration files ($main_config_file and resoures created by $configs)
+# @param main_config_group
+#   Group for configuration files ($main_config_file and resoures created by $configs)
+# @param main_config_mode
+#   chmod for configuration files ($main_config_file and resoures created by $configs)
 class sssd::base_config (
   # lint:ignore:parameter_types
   $config_manage  = $sssd::config_manage,
@@ -43,16 +57,39 @@ class sssd::base_config (
   $config_mode = $sssd::config_mode,
   $main_config = $sssd::main_config,
   $configs = $sssd::configs,
+  $advanced_permissions = $sssd::advanced_permissions,
+  $config_dir_owner = $sssd::config_dir_owner,
+  $config_dir_group = $sssd::config_dir_group,
+  $config_dir_mode = $sssd::config_dir_mode,
+  $main_config_owner = $sssd::main_config_owner,
+  $main_config_group = $sssd::main_config_group,
+  $main_config_mode = $sssd::main_config_mode,
   # lint:endignore
 ) inherits sssd {
   assert_private()
 
   if $config_manage {
+    if $advanced_permissions {
+      $_config_dir_owner = $config_dir_owner
+      $_config_dir_group = $config_dir_group
+      $_config_dir_mode = $config_dir_mode
+      $_main_config_owner = $main_config_owner
+      $_main_config_group = $main_config_group
+      $_main_config_mode = $main_config_mode
+    } else {
+      $_config_dir_owner = $config_owner
+      $_config_dir_group = $config_group
+      $_config_dir_mode = $config_mode
+      $_main_config_owner = $config_owner
+      $_main_config_group = $config_group
+      $_main_config_mode = $config_mode
+    }
+
     file { $main_config_dir:
       ensure => 'directory',
-      owner  => $config_owner,
-      group  => $config_group,
-      mode   => $config_mode,
+      owner  => $_config_dir_owner,
+      group  => $_config_dir_group,
+      mode   => $_config_dir_mode,
     }
 
     file { $main_pki_dir:
@@ -64,23 +101,23 @@ class sssd::base_config (
 
     file { $config_d_location:
       ensure  => 'directory',
-      owner   => $config_owner,
-      group   => $config_group,
-      mode    => $config_mode,
+      owner   => $_config_dir_owner,
+      group   => $_config_dir_group,
+      mode    => $_config_dir_mode,
       recurse => $purge_unmanaged_conf_d,
       purge   => $purge_unmanaged_conf_d,
     }
 
     sssd::config { $main_config_file:
-      owner               => $config_owner,
-      group               => $config_group,
-      mode                => $config_mode,
+      owner               => $_main_config_owner,
+      group               => $_main_config_group,
+      mode                => $_main_config_mode,
       stanzas             => $main_config,
       force_this_filename => $main_config_file,
     }
 
     # lint:ignore:140chars
-    create_resources(sssd::config, $configs, { 'owner' => $config_owner, 'group' => $config_group, 'mode' => $config_mode })
+    create_resources(sssd::config, $configs, { 'owner' => $_main_config_owner, 'group' => $_main_config_group, 'mode' => $_main_config_mode })
     # lint:endignore
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,20 @@
 #   Service enable parameter
 # @param service_names
 #   Array of services that are part of sssd
+# @param advanced_permissions
+#   Enable permission handling for files/directories
+# @param config_dir_owner
+#   Owner for configuration directories ($main_config_dir and $config_d_location)
+# @param config_dir_group
+#   Group for configuration directories ($main_config_dir and $config_d_location)
+# @param config_dir_mode
+#   chmod for configuration directories ($main_config_dir and $config_d_location)
+# @param main_config_owner
+#   Owner for configuration files ($main_config_file and resoures created by $configs)
+# @param main_config_group
+#   Group for configuration files ($main_config_file and resoures created by $configs)
+# @param main_config_mode
+#   chmod for configuration files ($main_config_file and resoures created by $configs)
 #
 # @example
 #   class { 'sssd':
@@ -89,6 +103,13 @@ class sssd (
   Enum['stopped','running'] $services_ensure,
   Boolean $services_enable,
   Array[String] $service_names,
+  Boolean $advanced_permissions,
+  String $config_dir_owner,
+  String $config_dir_group,
+  Stdlib::Filemode $config_dir_mode,
+  String $main_config_owner,
+  String $main_config_group,
+  Stdlib::Filemode $main_config_mode,
 ) {
   contain sssd::install
   contain sssd::base_config

--- a/spec/classes/base_config_spec.rb
+++ b/spec/classes/base_config_spec.rb
@@ -171,6 +171,50 @@ describe 'sssd::base_config' do
             with_stanzas({ 'nss' => { 'debug' => 0 } })
         }
       end
+
+      describe 'with advanced permissions' do
+        let(:params) do
+          {
+            'advanced_permissions' => true,
+            'configs' =>
+              {
+                'pam' =>
+                  {
+                    'stanzas' => { 'sssd' => { 'services' => ['pam'] } }
+                  },
+              }
+          }
+        end
+
+        it {
+          is_expected.to contain_file('/etc/sssd').
+            with_owner('root').
+            with_group('sssd').
+            with_mode('0750')
+        }
+
+        it {
+          is_expected.to contain_file('/etc/sssd/conf.d').
+            with_owner('root').
+            with_group('sssd').
+            with_mode('0750')
+        }
+
+        it {
+          is_expected.to contain_file('/etc/sssd/sssd.conf').
+            with_owner('root').
+            with_group('sssd').
+            with_mode('0640')
+        }
+
+        it {
+          is_expected.to contain_sssd__config('pam').
+            with_owner('root').
+            with_group('sssd').
+            with_mode('0640').
+            with_stanzas({ 'sssd' => { 'services' => ['pam'] } })
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Allow management of file/directory permissions  for configuration files required after sssd version 2.10.0. The included configuration works for me on Gentoo Linux. Not sure if they're valid for other OS families and if they should be updated  or omitted by default. This configuration is hidden behind sssd::advanced_permissions flag which is `false` by default.

In addition to the additional parameters added and their defaults the following parameters was also required:
```
sssd::pki_group: sssd
sssd::pki_mode: '0751'
sssd::advanced_permissions: true
```

README needs to be updated too.

#### This Pull Request (PR) fixes the following issues
Fixes #24 